### PR TITLE
feat:feat(wizpro-tools): adiciona header w-user-ip no interceptor de tenant

### DIFF
--- a/libs/wizpro-tools/package.json
+++ b/libs/wizpro-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizco/wizpro-tools",
-  "version": "20.2.3",
+  "version": "20.2.4",
   "peerDependencies": {
     "@angular/core": ">=17 <21",
     "@angular/router": ">=17 <21"

--- a/libs/wizpro-tools/src/service/interceptors/interceptor.token.ts
+++ b/libs/wizpro-tools/src/service/interceptors/interceptor.token.ts
@@ -98,7 +98,7 @@ export class WcoTenantInterceptor implements HttpInterceptor {
 
     const userIp = getDataSessionStorage('', 'w-user-ip');
     if (userIp) {
-      headers['w-user-ip'] = userIp;
+      headers['x-user-ip'] = userIp;
     }
 
     return request.clone({

--- a/libs/wizpro-tools/src/service/interceptors/interceptor.token.ts
+++ b/libs/wizpro-tools/src/service/interceptors/interceptor.token.ts
@@ -9,7 +9,10 @@ import { Injectable } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, delay, switchMap } from 'rxjs/operators';
 import { WcoEventsService } from '../share-events/share-events';
-import { getDataStorage } from '../../utils/token.storage';
+import {
+  getDataSessionStorage,
+  getDataStorage,
+} from '../../utils/token.storage';
 
 /**
  * Interceptor responsável por adicionar o cabeçalho 'x-tenant' e o token de autorização nas requisições HTTP.
@@ -84,11 +87,22 @@ export class WcoTenantInterceptor implements HttpInterceptor {
    * @returns A requisição HTTP modificada com o cabeçalho 'x-tenant'.
    */
   private addTenantHeader(request: HttpRequest<any>): HttpRequest<any> {
-    const tenant = getDataStorage('tenant', 'w-theme') || ' ';
+    const theme = getDataStorage('', 'w-theme') || ' ';
+    const tenantId = theme.tenantId || ' ';
+    const tenant = theme.tenant || ' ';
+
+    const headers: Record<string, string> = {
+      'x-tenant': tenant,
+      'x-tenant-id': tenantId,
+    };
+
+    const userIp = getDataSessionStorage('', 'w-user-ip');
+    if (userIp) {
+      headers['w-user-ip'] = userIp;
+    }
+
     return request.clone({
-      setHeaders: {
-        'x-tenant': tenant,
-      },
+      setHeaders: headers,
     });
   }
 

--- a/libs/wizpro-tools/src/utils/token.storage.ts
+++ b/libs/wizpro-tools/src/utils/token.storage.ts
@@ -27,6 +27,35 @@ export const setDataStorage = (data: any, storage = 'w-auth') => {
   localStorage.setItem(storage, JSON.stringify(data));
 };
 
+/**
+ * @description Função para pegar dados do sessionstorage
+ * @param (param: string | '', storage: string)
+ * @returns any
+ * @example getDataSessionStorage('', 'w-user-ip')
+*/
+export const getDataSessionStorage = (param: string | '', storage: string) => {
+  const data = sessionStorage.getItem(storage);
+  if (data) {
+    const verifyObject = data.startsWith('{') && data.endsWith('}');
+    const verifyArray = data.startsWith('[') && data.endsWith(']');
+    if (!verifyObject && !verifyArray) {
+      return data;
+    }
+    return param ? JSON.parse(data)[param] : JSON.parse(data);
+  }
+  return null;
+};
+
+/**
+ * @description Função para setar dados no sessionstorage
+ * @param (data: any, storage: string)
+ * @returns void
+ * @example setDataSessionStorage('token', 'w-user-ip')
+*/
+export const setDataSessionStorage = (data: any, storage: string) => {
+  sessionStorage.setItem(storage, JSON.stringify(data));
+};
+
 
 /**
  * @description Retorna o token do usuário


### PR DESCRIPTION


- Cria getDataSessionStorage/setDataSessionStorage em token.storage.ts
  para ler/gravar dados no sessionStorage (getDataStorage só cobria
  localStorage).
- WcoTenantInterceptor passa a incluir o header 'w-user-ip' na
  requisição quando o valor existir no sessionStorage, sem quebrar o
  fluxo quando ausente.
- Ajusta addTenantHeader para ler 'w-theme' como objeto único e extrair
  tenant/tenantId, mantendo os headers x-tenant e x-tenant-id.
- Bump de versão da lib wizpro-tools para 20.2.4.